### PR TITLE
Fix a problem with script ( resource ) renames.

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -959,8 +959,8 @@ void _OS::print_all_textures_by_size() {
 
     Vector<_OSCoreBindImg> imgs;
 
-    List<Ref<Resource> > rsrc;
-    ResourceCache::get_cached_resources(&rsrc);
+    Vector<Ref<Resource> > rsrc;
+    ResourceCache::get_cached_resources(rsrc);
     imgs.reserve(rsrc.size());
 
     for (const Ref<Resource> &E : rsrc) {
@@ -985,8 +985,8 @@ void _OS::print_resources_by_type(const Vector<String> &p_types) {
 
     HashMap<String, int> type_count;
 
-    List<Ref<Resource> > rsrc;
-    ResourceCache::get_cached_resources(&rsrc);
+    Vector<Ref<Resource> > rsrc;
+    ResourceCache::get_cached_resources(rsrc);
 
     for (const Ref<Resource> &r : rsrc) {
 

--- a/core/resource.cpp
+++ b/core/resource.cpp
@@ -93,7 +93,7 @@ void Resource::set_path(StringView p_path, bool p_take_over) {
         cached_resources.erase(impl_data->path_cache);
     }
     HashMap<String, Resource*>::iterator lociter;
-    bool has_path=false;
+    bool has_path;
     impl_data->path_cache.clear();
     {
         RWLockRead read_guard(ResourceCache::lock);
@@ -557,11 +557,12 @@ Resource *ResourceCache::get(StringView p_path) {
     return res;
 }
 
-void ResourceCache::get_cached_resources(List<Ref<Resource>> *p_resources) {
+void ResourceCache::get_cached_resources(Vector<Ref<Resource>> &p_resources) {
 
     lock->read_lock();
-    for(eastl::pair<const String,Resource *> & e :cached_resources) {
-        p_resources->push_back(Ref<Resource>(e.second));
+    p_resources.reserve(cached_resources.size());
+    for(eastl::pair<const String,Resource *> & e : cached_resources) {
+        p_resources.emplace_back(e.second);
     }
     lock->read_unlock();
 }

--- a/core/resource.h
+++ b/core/resource.h
@@ -175,10 +175,11 @@ class GODOT_EXPORT ResourceCache {
     friend class Resource;
     friend class ResourceManager; //need the lock
     friend class ResourceRemapper; //need the lock
-    static RWLock *lock;
     friend void unregister_core_types();
-    static void clear();
     friend void register_core_types();
+
+    static RWLock* lock;
+    static void clear();
     static void setup();
     static Resource *get_unguarded(StringView p_path);
 public:
@@ -186,6 +187,6 @@ public:
     static bool has(StringView p_path);
     static Resource *get(StringView p_path);
     static void dump(StringView p_file = nullptr, bool p_short = false);
-    static void get_cached_resources(List<Ref<Resource>> *p_resources);
+    static void get_cached_resources(Vector<Ref<Resource>> &p_resources);
     static int get_cached_resource_count();
 };

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1363,9 +1363,9 @@ int EditorNode::_save_external_resources() {
 
     Set<Ref<Resource>> edited_subresources;
     int saved = 0;
-    List<Ref<Resource>> cached;
-    ResourceCache::get_cached_resources(&cached);
-    for (Ref<Resource> res : cached) {
+    Vector<Ref<Resource>> cached;
+    ResourceCache::get_cached_resources(cached);
+    for (const Ref<Resource> &res : cached) {
 
         if (!PathUtils::is_resource_file(res->get_path()))
             continue;
@@ -5618,8 +5618,8 @@ void EditorNode::reload_scene(StringView p_path) {
 
     // first of all, reload internal textures, materials, meshes, etc. as they might have changed on disk
 
-    List<Ref<Resource>> cached;
-    ResourceCache::get_cached_resources(&cached);
+    Vector<Ref<Resource>> cached;
+    ResourceCache::get_cached_resources(cached);
     List<Ref<Resource>> to_clear; // clear internal resources from previous scene from being used
     for (const Ref<Resource> &E : cached) {
 
@@ -5630,7 +5630,7 @@ void EditorNode::reload_scene(StringView p_path) {
     }
 
     // so reload reloads everything, clear subresources of previous scene
-    while (to_clear.front()) {
+    while (!to_clear.empty()) {
         to_clear.front()->set_path({});
         to_clear.pop_front();
     }

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1122,9 +1122,9 @@ void FileSystemDock::_try_duplicate_item(const FileOrFolder &p_item, const Strin
 void FileSystemDock::_update_resource_paths_after_move(const HashMap<String, String> &p_renames) const {
 
     // Rename all resources loaded, be it subresources or actual resources.
-    List<Ref<Resource> > cached;
-    ResourceCache::get_cached_resources(&cached);
-
+    Vector<Ref<Resource> > cached;
+    ResourceCache::get_cached_resources(cached);
+    
     for (Ref<Resource> r : cached) {
 
         String base_path = r->get_path();


### PR DESCRIPTION
Previously there were 2 problems:
- leftover from upstrem code cuasing a crash, bad:
`while(to_clear.front())` vs proper `while(!to_clear.empty())`
- _update_resource_paths_after_move sometimes tried to update the path
of a same resource twice ( unsure how it got there )

Fixes: #60